### PR TITLE
Fix mkdocs plugin name

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ theme:
 
 plugins:
   - search
-  - gen_nav
+  - gen-nav
   - mermaid2
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- fix plugin name `gen_nav` -> `gen-nav`

## Testing
- `mkdocs build -q` *(fails: mkdocs not installed)*