### PR TITLE
Update MkDocs build for strict mode

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Build site
-        run: mkdocs build --clean
+        run: mkdocs build --strict --clean
 
       - name: Upload artifact for GitHub Pages
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
## Summary
- enforce `mkdocs build --strict --clean` in deploy workflow

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement mkdocs)*
- `mkdocs serve` *(fails: command not found)*