### PR TITLE
Fix deploy step for GH Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,4 +44,7 @@ jobs:
         uses: actions/configure-pages@v4
         with:
           branch: gh-pages
-          path: /
+          path: ./site
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
## Summary
- fix path for GitHub Pages configuration
- add missing deploy action step

## Testing
- `mkdocs build --strict` *(fails: mkdocs not installed)*
- `pip install -r requirements.txt` *(fails: no network access)*