### PR TITLE
Add contribution docs and commit rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,7 @@ When Codex is used to continue or enhance this repo, it must:
 - Monitor the GitHub Actions workflow runs and report any failures via https://github.com/tom-mcmillan/research/actions
 - Make all styling decisions based on Material theme defaults, except header background override via CSS
 - Keep PRs small and auditable (clear commit messages, minimal blast radius)
+- Summarize commit messages with what changed (e.g. "Add MkDocs docs and config")
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing Guide
+
+Thank you for helping improve this documentation site!
+
+## Setup
+1. Create a Python 3.11 virtual environment and activate it:
+   ```bash
+   python3.11 -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Preview the site locally with:
+   ```bash
+   mkdocs serve
+   ```
+
+## Guidelines
+- Make changes inside the `docs/` directory whenever possible.
+- Do **not** commit build output (`site/`), `.DS_Store`, or other system files.
+- Keep pull requests focused and easy to review.
+- Summarize commit messages with what changed (e.g. "Add MkDocs docs and config").
+- The navigation is handled automatically by `awesome-nav` using `docs/.nav.yml`.
+
+Once your changes are pushed to the `main` branch, GitHub Actions will build and deploy the site.

--- a/README.md
+++ b/README.md
@@ -47,3 +47,8 @@ https://tom-mcmillan.github.io/research/
 ```bash
 mkdocs gh-deploy --clean
 ```
+
+## Contributing
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for setup steps and
+guidelines. Commit messages should briefly state what changed.


### PR DESCRIPTION
## Summary
- document commit style requirement in AGENTS
- add CONTRIBUTING guide
- reference contribution doc from README

## Testing
- `mkdocs build`