### PR TITLE
Add pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: mkdocs build --strict --clean
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - uses: actions/configure-pages@v4
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ mkdocs serve
 ```
 
 Then open <http://127.0.0.1:8000> in your browser.
-## Continuous Deployment
-This site uses MkDocs Material and is automatically built and deployed to GitHub Pages via GitHub Actions whenever you push changes to the `main` branch.
 
-> **No manual Pages setup is required**—the GitHub Actions workflow defined in `.github/workflows/pages.yml` configures and publishes the site for you.
->
-> You can monitor build and deployment status via the badge at the top of this README or by visiting the [Actions tab](https://github.com/tom-mcmillan/research/actions).
+## Continuous Deployment
+Changes pushed to `main` automatically trigger the [pages.yml](.github/workflows/pages.yml)
+workflow. It installs dependencies, builds the site with MkDocs, and publishes
+the output to GitHub Pages using the official actions.
+
+You can monitor build and deployment status via the badge at the top of this README
+or by visiting the [Actions tab](https://github.com/tom-mcmillan/research/actions).
 
 Simply commit and push your Markdown files to `main`, and your documentation will be live at:
 


### PR DESCRIPTION
## Summary
- restore CI workflow for GitHub Pages
- refine README instructions for automatic deployment

## Testing
- `mkdocs build --strict --clean` *(fails: Cannot check URL - no Internet access)*